### PR TITLE
feat: launchserver extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ The following is the list of supported scopes:
 * `client`
 * `server`
 * `api`
+* `extensions`  
 * `macro`
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = [
     "launcher",
     "launchserver",
     "launcherapi",
-    "utils-macro"
+    "utils-macro",
+    "extensions-api"
 ]
 
 [profile.release]

--- a/extensions-api/Cargo.toml
+++ b/extensions-api/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "launcher_extension_api"
+version = "0.0.1"
+authors = ["RussianJeb", "Belz"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+tokio = { version = "1.2", features = ["sync"] }
+launcher_api = { path = "../launcherapi" }
+uuid = { version = "0.8" }

--- a/extensions-api/src/channel.rs
+++ b/extensions-api/src/channel.rs
@@ -1,0 +1,1 @@
+pub use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};

--- a/extensions-api/src/command.rs
+++ b/extensions-api/src/command.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+pub struct ExtensionCommand {
+    pub name: String,
+    pub description: String,
+    pub executor: Box<dyn ExtensionCommandExecutor>,
+}
+
+pub trait ExtensionCommandExecutor: Send {
+    fn execute(&self, args: &[&str]);
+}
+
+pub struct CommandRegister {
+    extension_commands: HashMap<String, ExtensionCommand>,
+}
+
+impl Default for CommandRegister {
+    fn default() -> Self {
+        CommandRegister {
+            extension_commands: Default::default(),
+        }
+    }
+}
+
+impl CommandRegister {
+    pub fn register(
+        &mut self,
+        name: &str,
+        description: &str,
+        command: Box<dyn ExtensionCommandExecutor>,
+    ) {
+        let command = ExtensionCommand {
+            name: name.to_string(),
+            description: description.to_string(),
+            executor: command,
+        };
+        self.extension_commands
+            .insert(command.name.clone(), command);
+    }
+
+    pub fn into_commands(self) -> HashMap<String, ExtensionCommand> {
+        self.extension_commands
+    }
+}

--- a/extensions-api/src/launcher.rs
+++ b/extensions-api/src/launcher.rs
@@ -1,0 +1,1 @@
+pub use launcher_api::*;

--- a/extensions-api/src/lib.rs
+++ b/extensions-api/src/lib.rs
@@ -1,0 +1,16 @@
+use crate::command::CommandRegister;
+
+pub use anyhow::{anyhow, Context, Error, Result};
+
+pub use uuid::Uuid;
+
+pub mod channel;
+pub mod command;
+pub mod launcher;
+
+pub trait LauncherExtension: Send + Sync {
+    fn register_command(&self, _register: &mut CommandRegister) {}
+    fn init(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -24,7 +24,6 @@ futures = "0.3"
 anyhow = "1.0.31"
 notify = "5.0.0-pre.2"
 once_cell = "1.5"
-uuid = "0.8"
 log = "0.4"
 bincode = "1.3"
 nfd2 = "0.2"
@@ -32,6 +31,10 @@ t1ha = "0.1.0"
 sysinfo = "0.15"
 obfstr = "0.2"
 lazy-static-include = "3.0.5"
+
+[dependencies.uuid]
+version = "0.8"
+features = ["v4"]
 
 [dependencies.web-view]
 git = "https://github.com/team-ns/web-view"

--- a/launcher/src/client.rs
+++ b/launcher/src/client.rs
@@ -1,27 +1,30 @@
 use anyhow::{anyhow, Result};
 
 use launcher_api::message::{
-    AuthMessage, AuthResponse, ClientMessage, JoinServerMessage, ProfileMessage, ProfileResponse,
-    ProfilesInfoMessage, ProfilesInfoResponse, ServerMessage,
+    AuthMessage, AuthResponse, ClientMessage, ClientRequest, JoinServerMessage, ProfileMessage,
+    ProfileResponse, ProfilesInfoMessage, ProfilesInfoResponse, ServerMessage, ServerResponse,
 };
 use launcher_api::message::{Error, ProfileResourcesMessage, ProfileResourcesResponse};
 
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::CONFIG;
 
 use crate::security;
 use crate::security::validation::get_os_type;
 use crate::security::SecurityManager;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use uuid::Uuid;
 
 pub mod downloader;
 
 pub struct Client {
-    out: Sender<String>,
-    recv: Receiver<String>,
+    out: mpsc::Sender<String>,
     security: SecurityManager,
     pub auth_info: Option<AuthInfo>,
+    requests: Arc<Mutex<HashMap<Uuid, oneshot::Sender<ServerMessage>>>>,
 }
 
 #[derive(Clone)]
@@ -32,18 +35,43 @@ pub struct AuthInfo {
 }
 
 impl Client {
-    pub async fn new() -> Result<Self> {
+    pub async fn new(runtime_sender: UnboundedSender<String>) -> Result<Self> {
         let address: &str = &CONFIG.websocket;
-        let (s, r) = Client::connect(&address).await?;
+        let (out, mut r) = Client::connect(&address).await?;
+        let requests: Arc<Mutex<HashMap<Uuid, oneshot::Sender<ServerMessage>>>> =
+            Arc::new(Mutex::new(HashMap::default()));
+        let response_requests = requests.clone();
+        tokio::spawn(async move {
+            loop {
+                match r.recv().await {
+                    None => {
+                        break;
+                    }
+                    Some(m) => {
+                        let response = serde_json::from_str::<ServerResponse>(&m)
+                            .expect("Can't parse response");
+
+                        if let Some(request_id) = response.request_id {
+                            let mut requests = response_requests.lock().await;
+                            if let Some(sender) = requests.remove(&request_id) {
+                                sender.send(response.message).expect("Can't send message");
+                            }
+                        } else if let ServerMessage::Runtime(message) = response.message {
+                            runtime_sender.send(message).expect("Can't send message");
+                        }
+                    }
+                }
+            }
+        });
         Ok(Client {
             security: security::get_manager(),
-            recv: r,
-            out: s,
+            out,
             auth_info: None,
+            requests,
         })
     }
 
-    async fn connect(address: &str) -> Result<(Sender<String>, Receiver<String>)> {
+    async fn connect(address: &str) -> Result<(mpsc::Sender<String>, mpsc::Receiver<String>)> {
         let ws = yarws::Client::new(address)
             .connect()
             .await
@@ -114,14 +142,24 @@ impl Client {
     }
 
     async fn send_sync(&mut self, msg: ClientMessage) -> ServerMessage {
+        let request_uuid = uuid::Uuid::new_v4();
+        let request = ClientRequest {
+            request_id: request_uuid,
+            message: msg,
+        };
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        {
+            let mut requests = self.requests.lock().await;
+            requests.insert(request_uuid, sender);
+        }
         self.out
-            .send(serde_json::to_string(&msg).unwrap())
+            .send(serde_json::to_string(&request).unwrap())
             .await
             .expect("Can't send message to server");
-        match self.recv.recv().await {
-            Some(message) => serde_json::from_str(&message).unwrap(),
-            None => ServerMessage::Error(Error {
-                msg: "Server Disconnected".to_string(),
+        match receiver.await {
+            Ok(message) => message,
+            Err(e) => ServerMessage::Error(Error {
+                msg: format!("Server Disconnected: {}", e),
             }),
         }
     }

--- a/launcher/src/client.rs
+++ b/launcher/src/client.rs
@@ -142,7 +142,7 @@ impl Client {
     }
 
     async fn send_sync(&mut self, msg: ClientMessage) -> ServerMessage {
-        let request_uuid = uuid::Uuid::new_v4();
+        let request_uuid = Uuid::new_v4();
         let request = ClientRequest {
             request_id: request_uuid,
             message: msg,

--- a/launcher/src/runtime.rs
+++ b/launcher/src/runtime.rs
@@ -37,8 +37,9 @@ macro_rules! handle_error {
 
 pub async fn start() {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let (runtime_message_tx, mut runtime_message_rx) = tokio::sync::mpsc::unbounded_channel();
     let message_handle = tokio::task::spawn(async move {
-        message_loop(rx).await;
+        message_loop(rx, runtime_message_tx).await;
     });
     let ui_handle = tokio::task::spawn_blocking(move || {
         let webview = web_view::builder()
@@ -51,12 +52,28 @@ pub async fn start() {
             .invoke_handler(move |view, arg| invoke_handler(view, arg, tx.clone()))
             .build()
             .expect("Can't create webview runtime");
+        let handle = webview.handle();
+        tokio::spawn(async move {
+            loop {
+                match runtime_message_rx.recv().await {
+                    None => break,
+                    Some(message) => {
+                        handle
+                            .dispatch(move |wv| {
+                                wv.eval(&format!(
+                                    r#"app.backend.customMessage('{}')"#,
+                                    message.replace(r#"""#, r#"""#)
+                                ))?;
+                                Ok(())
+                            })
+                            .expect("Can't eval message request");
+                    }
+                }
+            }
+        });
         webview.run().expect("Can't run webview runtime");
     });
     ui_handle.await.expect("Can't execute ui loop");
-    if PLAYING.get().is_none() {
-        std::process::exit(0);
-    }
     message_handle.await.expect("Can't execute message loop");
 }
 
@@ -75,7 +92,10 @@ fn invoke_handler(
     Ok(())
 }
 
-async fn message_loop(mut recv: UnboundedReceiver<(RuntimeMessage, Handle<()>)>) {
+async fn message_loop(
+    mut recv: UnboundedReceiver<(RuntimeMessage, Handle<()>)>,
+    sender: UnboundedSender<String>,
+) {
     loop {
         match recv.recv().await {
             None => {
@@ -105,7 +125,10 @@ async fn message_loop(mut recv: UnboundedReceiver<(RuntimeMessage, Handle<()>)>)
                         )
                     }
                     RuntimeMessage::Ready => {
-                        handle_error!(error_handler, messages::ready(handler).await)
+                        handle_error!(
+                            error_handler,
+                            messages::ready(handler, sender.clone()).await
+                        )
                     }
                     RuntimeMessage::SelectGameDir => {
                         handle_error!(error_handler, messages::select_game_dir(handler).await)

--- a/launcherapi/src/message.rs
+++ b/launcherapi/src/message.rs
@@ -4,7 +4,19 @@ use uuid::Uuid;
 use crate::profile::{Profile, ProfileInfo};
 use crate::validation::{OsType, RemoteDirectory};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ClientRequest {
+    pub request_id: Uuid,
+    pub message: ClientMessage,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ServerResponse {
+    pub request_id: Option<Uuid>,
+    pub message: ServerMessage,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 pub enum ClientMessage {
     Auth(AuthMessage),
     JoinServer(JoinServerMessage),
@@ -13,54 +25,55 @@ pub enum ClientMessage {
     ProfilesInfo(ProfilesInfoMessage),
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub enum ServerMessage {
     Auth(AuthResponse),
     ProfileResources(ProfileResourcesResponse),
     Profile(ProfileResponse),
     ProfilesInfo(ProfilesInfoResponse),
+    Runtime(String),
     Empty,
     Error(Error),
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct AuthMessage {
     pub login: String,
     pub password: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct JoinServerMessage {
     pub access_token: String,
     pub selected_profile: Uuid,
     pub server_id: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfileResourcesMessage {
     pub profile: String,
     pub os_type: OsType,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfileMessage {
     pub profile: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfilesInfoMessage;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfileResponse {
     pub profile: Profile,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfilesInfoResponse {
     pub profiles_info: Vec<ProfileInfo>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct ProfileResourcesResponse {
     pub profile: RemoteDirectory,
     pub libraries: RemoteDirectory,
@@ -69,14 +82,14 @@ pub struct ProfileResourcesResponse {
     pub jre: RemoteDirectory,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthResponse {
     pub uuid: String,
     pub access_token: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Error {
     pub msg: String,
 }

--- a/launcherapi/src/profile.rs
+++ b/launcherapi/src/profile.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Profile {
     pub name: String,
@@ -18,7 +18,7 @@ pub struct Profile {
     pub server_port: u32,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ProfileInfo {
     pub name: String,
     pub version: String,

--- a/launcherapi/src/validation.rs
+++ b/launcherapi/src/validation.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct HashedFile {
     pub size: u64,
     pub checksum: u128,
 }
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct RemoteFile {
     pub uri: String,
     pub size: u64,
@@ -23,7 +23,7 @@ impl PartialEq<RemoteFile> for HashedFile {
 
 pub type RemoteDirectory = HashMap<PathBuf, RemoteFile>;
 
-#[derive(Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub enum OsType {
     LinuxX64,
     LinuxX32,

--- a/launchserver/Cargo.toml
+++ b/launchserver/Cargo.toml
@@ -25,13 +25,17 @@ anyhow = "1.0"
 log4rs = "0.13"
 path-slash = "0.1.1"
 tokio-stream = "0.1"
-
+libloading = "0.7"
+dlopen = "0.1"
 
 [dependencies.launcher_api]
 path = "../launcherapi"
 
 [dependencies.launcher_macro]
 path = "../utils-macro"
+
+[dependencies.launcher_extension_api]
+path = "../extensions-api"
 
 [dependencies.serde]
 version = "1.0"
@@ -42,7 +46,7 @@ version = "0.8"
 features = ["serde", "v4"]
 
 [dependencies.tokio]
-version = "1.0"
+version = "1.2"
 features = ["full"]
 
 [dependencies.reqwest]

--- a/launchserver/src/commands.rs
+++ b/launchserver/src/commands.rs
@@ -120,7 +120,7 @@ pub async fn start(server: Arc<RwLock<LaunchServer>>) {
             .output_stream(OutputStreamType::Stdout)
             .build();
         let mut rl: Editor<CommandHelper> = Editor::with_config(rl_config);
-        let mut helper = CommandHelper::new(server);
+        let mut helper = CommandHelper::new(server).await;
         register_commands!(rehash, sync, auth);
         rl.set_helper(Some(helper));
         loop {

--- a/launchserver/src/extensions.rs
+++ b/launchserver/src/extensions.rs
@@ -1,0 +1,66 @@
+use dlopen::symbor::{Library, Symbol};
+
+use launcher_extension_api::command::{CommandRegister, ExtensionCommand};
+
+use launcher_extension_api::{LauncherExtension, Result};
+use std::collections::HashMap;
+use std::fs;
+
+#[cfg(target_os = "linux")]
+const FILE_EXTENSION: &str = "so";
+#[cfg(target_os = "macos")]
+const FILE_EXTENSION: &str = "dylib";
+#[cfg(target_os = "windows")]
+const FILE_EXTENSION: &str = "dll";
+
+type ExtensionFn = fn() -> (String, Box<dyn LauncherExtension>);
+
+pub struct ExtensionManager {
+    extensions: HashMap<String, DynamicExtension>,
+}
+
+pub struct DynamicExtension {
+    _lib: Library,
+    pub extension: Box<dyn LauncherExtension>,
+}
+
+impl ExtensionManager {
+    pub fn load_extensions() -> Self {
+        fs::create_dir_all("extensions").expect("Can't create extension folder");
+        let mut extensions = HashMap::new();
+        for entry in crate::util::get_files_from_dir("extensions").filter(|e| {
+            e.path()
+                .extension()
+                .map(|ex| ex.eq(FILE_EXTENSION))
+                .unwrap_or(false)
+        }) {
+            let lib = Library::open(entry.path()).expect("Can't load library");
+            let new_extension: Symbol<ExtensionFn> =
+                unsafe { lib.symbol("new_extension") }.expect("Can't load symbol");
+            let extension: (String, Box<dyn LauncherExtension>) = new_extension();
+            let dynamic_extension = DynamicExtension {
+                _lib: lib,
+                extension: extension.1,
+            };
+            extensions.insert(extension.0, dynamic_extension);
+        }
+        ExtensionManager { extensions }
+    }
+
+    pub fn initialize_extensions(&self) -> Result<()> {
+        for de in self.extensions.values() {
+            de.extension.init()?
+        }
+        Ok(())
+    }
+
+    pub fn get_commands(&self) -> HashMap<String, HashMap<String, ExtensionCommand>> {
+        let mut commands = HashMap::new();
+        for (extension_name, dynamic_extension) in &self.extensions {
+            let mut register = CommandRegister::default();
+            dynamic_extension.extension.register_command(&mut register);
+            commands.insert(extension_name.to_string(), register.into_commands());
+        }
+        commands
+    }
+}

--- a/launchserver/src/main.rs
+++ b/launchserver/src/main.rs
@@ -9,15 +9,18 @@ use tokio::sync::RwLock;
 
 use crate::auth::AuthProvider;
 use crate::config::Config;
+use crate::extensions::ExtensionManager;
 use crate::security::SecurityManager;
 
 mod auth;
 mod bundle;
 mod commands;
 mod config;
+mod extensions;
 mod logger;
 mod security;
 mod server;
+mod util;
 
 pub struct LaunchServer {
     pub config: Config,
@@ -25,6 +28,7 @@ pub struct LaunchServer {
     pub profiles: HashMap<String, Profile>,
     pub profiles_info: Vec<ProfileInfo>,
     pub auth_provider: AuthProvider,
+    pub extension_manager: ExtensionManager,
 }
 
 impl LaunchServer {
@@ -33,7 +37,11 @@ impl LaunchServer {
         bundle::unpack_launcher();
         info!("Read config file...");
         let config = Config::get_config(Path::new("config.json")).expect("Can't read config file!");
-        info!("Launch server starting...");
+        info!("Load extensions...");
+        let extension_manager = ExtensionManager::load_extensions();
+        extension_manager
+            .initialize_extensions()
+            .expect("Can't initialize extension");
         let (profiles, profiles_info) = profile::get_profiles();
         let mut security = SecurityManager::default();
         security.rehash(profiles.values(), &[], config.file_server.clone());
@@ -42,13 +50,13 @@ impl LaunchServer {
             .get_provider()
             .await
             .expect("Can't initialize auth provider");
-
         LaunchServer {
             config,
             security,
             profiles,
             profiles_info,
             auth_provider,
+            extension_manager,
         }
     }
 }
@@ -56,6 +64,7 @@ impl LaunchServer {
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let data = Arc::new(RwLock::new(LaunchServer::new().await));
+    info!("Launchserver starting...");
     tokio::join!(commands::start(data.clone()), server::start(data.clone()));
     Ok(())
 }

--- a/launchserver/src/server.rs
+++ b/launchserver/src/server.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use warp::{Filter, Reply};
 use warp::http::StatusCode;
+use warp::{Filter, Reply};
 
 use crate::server::auth::{has_join, HasJoinRequest};
 use crate::server::websocket::ws_api;
@@ -46,15 +46,16 @@ pub async fn start(data: Arc<RwLock<LaunchServer>>) {
 fn check_black_list(file: warp::filters::fs::File) -> warp::reply::Response {
     let mut iter = file.path().iter().skip(1);
     if let Some(os_str) = iter.next() {
-        if Path::new(os_str).starts_with("profiles")
-            && iter.last().map_or(false, |os_str| {
+        if Path::new(os_str).starts_with("profiles") {
+            let black_list_check = iter.last().map_or(false, |os_str| {
                 let path: &Path = os_str.as_ref();
                 profile::BLACK_LIST
                     .iter()
                     .any(|&file_name| path.ends_with(file_name))
-            })
-        {
-            return StatusCode::NOT_FOUND.into_response();
+            });
+            if black_list_check {
+                return StatusCode::NOT_FOUND.into_response();
+            }
         }
     }
     file.into_response()

--- a/launchserver/src/util.rs
+++ b/launchserver/src/util.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use path_slash::PathBufExt;
+use walkdir::{DirEntry, WalkDir};
+
+pub fn strip_folder(path: &Path, save_number: usize, skip_number: usize) -> String {
+    path.iter()
+        .take(save_number)
+        .chain(path.iter().skip(save_number + skip_number))
+        .collect::<PathBuf>()
+        .to_slash_lossy()
+}
+
+pub fn get_files_from_dir<P: AsRef<Path>>(path: P) -> impl Iterator<Item = DirEntry> {
+    WalkDir::new(path)
+        .min_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.metadata().map(|m| m.is_file()).unwrap_or(false))
+}
+
+pub fn get_first_level_dirs<P: AsRef<Path>>(path: P) -> impl Iterator<Item = DirEntry> {
+    WalkDir::new(path)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.metadata().map(|m| m.is_dir()).unwrap_or(false))
+}
+
+pub fn strip(path: &Path, prefix: &str) -> Result<String> {
+    Ok(path
+        .strip_prefix(prefix)?
+        .to_str()
+        .with_context(|| {
+            format!(
+                "Can't strip prefix for path {:?}, maybe it is have non unicode chars!",
+                path
+            )
+        })?
+        .to_string())
+}


### PR DESCRIPTION
Это предварительная версия расширений в котором пока что реализовано только создание новых команд для лаунчсервера.

Кроме этого добавлена асинхронная обработка сообщений на лаунчере.

Для реализации удобного API в расширениях необходимо:

1. Возможность отправки сообщений по логину пользователя или uuid подключения
2. Получение информации о текущем пользователе по логину пользователя или uuid подключения